### PR TITLE
Change type of Domain's field

### DIFF
--- a/DNS/Protocol/Domain.cs
+++ b/DNS/Protocol/Domain.cs
@@ -113,7 +113,7 @@ namespace DNS.Protocol {
         }
 
         public int CompareTo(Domain other) {
-            return ToString().CompareTo(other.ToString());
+            return ToString().ToLower().CompareTo(other.ToString().ToLower());
         }
 
         public override bool Equals(object obj) {

--- a/Tests/Protocol/CompareDomainTest.cs
+++ b/Tests/Protocol/CompareDomainTest.cs
@@ -1,0 +1,89 @@
+using Xunit;
+using DNS.Protocol;
+
+namespace DNS.Tests.Protocol {
+
+    public class CompareDomainTest {
+        [Fact]
+        public void SameDomainInstance() {
+            Domain domain = new Domain(Helper.GetArray("www"));
+            Assert.Equal(0, domain.CompareTo(domain));
+        }
+
+        [Fact]
+        public void SameDomainsWithSingleLabelDifferentCasing() {
+            Domain a = new Domain(Helper.GetArray("www"));
+            Domain b = new Domain(Helper.GetArray("WWW"));
+
+            Assert.Equal(0, a.CompareTo(b));
+        }
+
+        [Fact]
+        public void SameDomainsWithSingleLabelNonAlphabeticCodes() {
+            Domain a = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 0, 119)
+            ));
+            Domain b = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 0, 119)
+            ));
+
+            Assert.Equal(0, a.CompareTo(b));
+        }
+
+        [Fact]
+        public void SameDomainsWithMultipleLabels() {
+            Domain a = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 119, 119),
+                Helper.GetArray<byte>(103, 111, 111, 103, 108, 101),
+                Helper.GetArray<byte>(99, 0, 109)
+            ));
+            Domain b = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(87, 87, 87),
+                Helper.GetArray<byte>(103, 79, 79, 103, 108, 101),
+                Helper.GetArray<byte>(99, 0, 77)
+            ));
+
+            Assert.Equal(0, a.CompareTo(b));
+        }
+
+        [Fact]
+        public void DifferentDomainsWithSingleLabelSameLength() {
+            Domain a = new Domain(Helper.GetArray("aww"));
+            Domain b = new Domain(Helper.GetArray("www"));
+
+            Assert.True(a.CompareTo(b) < 0);
+            Assert.True(b.CompareTo(a) > 0);
+        }
+
+        [Fact]
+        public void DifferentDomainsWithSingleLabelDifferentLength() {
+            Domain a = new Domain(Helper.GetArray("ww"));
+            Domain b = new Domain(Helper.GetArray("www"));
+
+            Assert.True(a.CompareTo(b) < 0);
+            Assert.True(b.CompareTo(a) > 0);
+        }
+
+        [Fact]
+        public void DifferentDomainsWithSingleLabelNonAlphabeticCodes() {
+            Domain a = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 0, 119)
+            ));
+            Domain b = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 119, 119)
+            ));
+
+            Assert.True(a.CompareTo(b) < 0);
+            Assert.True(b.CompareTo(a) > 0);
+        }
+
+        [Fact]
+        public void DifferentDomainsWithMultipleLabelsDifferentAmount() {
+            Domain a = new Domain(Helper.GetArray("www"));
+            Domain b = new Domain(Helper.GetArray("www", "google"));
+
+            Assert.True(a.CompareTo(b) < 0);
+            Assert.True(b.CompareTo(a) > 0);
+        }
+    }
+}

--- a/Tests/Protocol/SerializeDomainTest.cs
+++ b/Tests/Protocol/SerializeDomainTest.cs
@@ -2,7 +2,7 @@
 using DNS.Protocol;
 
 namespace DNS.Tests.Protocol {
-    
+
     public class SerializeDomainTest {
         [Fact]
         public void EmptyDomain() {
@@ -10,6 +10,7 @@ namespace DNS.Tests.Protocol {
             byte[] content = Helper.ReadFixture("Domain", "empty-label");
 
             Assert.Equal(content, domain.ToArray());
+            Assert.Equal("", domain.ToString());
         }
 
         [Fact]
@@ -18,6 +19,7 @@ namespace DNS.Tests.Protocol {
             byte[] content = Helper.ReadFixture("Domain", "www-label");
 
             Assert.Equal(content, domain.ToArray());
+            Assert.Equal("www", domain.ToString());
         }
 
         [Fact]
@@ -26,6 +28,31 @@ namespace DNS.Tests.Protocol {
             byte[] content = Helper.ReadFixture("Domain", "www.google.com-label");
 
             Assert.Equal(content, domain.ToArray());
+            Assert.Equal("www.google.com", domain.ToString());
+        }
+
+        [Fact]
+        public void DomainWithSingleBinaryLabel() {
+            Domain domain = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 119, 119)
+            ));
+            byte[] content = Helper.ReadFixture("Domain", "www-label");
+
+            Assert.Equal(content, domain.ToArray());
+            Assert.Equal("www", domain.ToString());
+        }
+
+        [Fact]
+        public void DomainWithMultipleBinaryLabels() {
+            Domain domain = new Domain(Helper.GetArray<byte[]>(
+                Helper.GetArray<byte>(119, 119, 119),
+                Helper.GetArray<byte>(103, 111, 111, 103, 108, 101),
+                Helper.GetArray<byte>(99, 111, 109)
+            ));
+            byte[] content = Helper.ReadFixture("Domain", "www.google.com-label");
+
+            Assert.Equal(content, domain.ToArray());
+            Assert.Equal("www.google.com", domain.ToString());
         }
     }
 }


### PR DESCRIPTION
[RFC 1035](https://tools.ietf.org/html/rfc1035) allows domain labels to contain any value (not just ASCII). This change allows developers to read and write arbitrary `byte[]`s as labels.

To maintain backwards compatibility, all of the methods that use `string`s still convert the `byte`s to ASCII before storing them.

Also, domain names with the same spelling but different case must be treated as identical. 