### PR TITLE
Make timeout on UdpRequestResolver configurable

### DIFF
--- a/DNS/Client/RequestResolver/UdpRequestResolver.cs
+++ b/DNS/Client/RequestResolver/UdpRequestResolver.cs
@@ -7,16 +7,18 @@ using DNS.Protocol.Utils;
 
 namespace DNS.Client.RequestResolver {
     public class UdpRequestResolver : IRequestResolver {
-        private const int TIMEOUT = 5000;
+        private readonly int timeout;
 
         private IRequestResolver fallback;
 
-        public UdpRequestResolver(IRequestResolver fallback) {
+        public UdpRequestResolver(IRequestResolver fallback, int timeout = 5000) {
             this.fallback = fallback;
+            this.timeout = timeout;
         }
 
-        public UdpRequestResolver() {
+        public UdpRequestResolver(int timeout = 5000) {
             this.fallback = new NullRequestResolver();
+            this.timeout = timeout;
         }
 
         public async Task<ClientResponse> Request(ClientRequest request) {
@@ -25,9 +27,9 @@ namespace DNS.Client.RequestResolver {
             using(UdpClient udp = new UdpClient()) {
                 await udp
                     .SendAsync(request.ToArray(), request.Size, dns)
-                    .WithCancellationTimeout(TIMEOUT);
+                    .WithCancellationTimeout(timeout);
 
-                UdpReceiveResult result = await udp.ReceiveAsync().WithCancellationTimeout(TIMEOUT);
+                UdpReceiveResult result = await udp.ReceiveAsync().WithCancellationTimeout(timeout);
                 if(!result.RemoteEndPoint.Equals(dns)) throw new IOException("Remote endpoint mismatch");
                 byte[] buffer = result.Buffer;
                 Response response = Response.FromArray(buffer);


### PR DESCRIPTION
Timeout on UdpRequestResolver is currently hardcoded to 5 seconds. Made it configurable.