### PR TITLE
Added support for DNS TXT resource-records

### DIFF
--- a/DNS/Protocol/CharacterString.cs
+++ b/DNS/Protocol/CharacterString.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DNS.Protocol {
+
+    /// <summary>
+    /// Implementation of the "character-string" non-terminal as defined in
+    /// RFC1035 (chapter 3.3):
+    ///   "character-string" is a single length octet followed by that number of
+    ///    characters. "character-string" is treated as binary information, and
+    ///    can be up to 256 characters in length (including the length octet).
+    /// </summary>
+    public class CharacterString {
+
+        private const int MAX_SIZE = byte.MaxValue;
+
+        public static CharacterString FromArray(byte[] message, int offset) {
+            return FromArray(message, offset, out offset);
+        }
+
+        public static CharacterString FromArray(byte[] message, int offset, out int endOffset) {
+            if (message.Length < 1) {
+                throw new ArgumentException("Empty message");
+            }
+            byte[] value;
+            endOffset = 0;
+            var len = message[offset++];
+            value = new byte[len];
+            Buffer.BlockCopy(message, offset, value, 0, len);
+            endOffset = offset + len;
+            return new CharacterString(value);
+        }
+
+        public static IEnumerable<CharacterString> FromString(string message) {
+            return FromString(message, Encoding.ASCII);
+        }
+
+        public static IEnumerable<CharacterString> FromString(string message, Encoding encoding) {
+            var bytes = encoding.GetBytes(message);
+            for (var i = 0; i < bytes.Length; i += MAX_SIZE) {
+                var len = Math.Min(bytes.Length - i, MAX_SIZE);
+                var chunk = new byte[len + 1];
+                chunk[0] = (byte)len;
+                Buffer.BlockCopy(bytes, i, chunk, 1, len);
+                yield return new CharacterString(chunk);
+            }
+        }
+
+        private CharacterString(byte[] value) => Value = value;
+
+        public byte[] Value { get; }
+
+        public string ToString(Encoding encoding) {
+            return encoding.GetString(Value);
+        }
+
+        public override string ToString() {
+            return ToString(Encoding.ASCII);
+        }
+    }
+}

--- a/DNS/Protocol/ResourceRecords/ResourceRecordFactory.cs
+++ b/DNS/Protocol/ResourceRecords/ResourceRecordFactory.cs
@@ -39,6 +39,8 @@ namespace DNS.Protocol.ResourceRecords {
                     return new PointerResourceRecord(record, message, dataOffset);
                 case RecordType.MX:
                     return new MailExchangeResourceRecord(record, message, dataOffset);
+                case RecordType.TXT:
+                    return new TxtResourceRecord(record, message, dataOffset);
                 default:
                     return record;
             }

--- a/DNS/Protocol/ResourceRecords/TxtResourceRecord.cs
+++ b/DNS/Protocol/ResourceRecords/TxtResourceRecord.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DNS.Protocol.ResourceRecords {
+    public class TxtResourceRecord : BaseResourceRecord {
+        /// Regular expression that matches the attribute name/value.
+        /// The first unescaped equal sign is the name/value delimiter.
+        private static readonly Regex PATTERN_TXT_RECORD = new Regex(@"^([ -~]*?)(?<!`)=([ -~]*)$");
+
+        /// Regular expression that matches unescaped leading/trailing whitespace.
+        private static readonly Regex PATTERN_TRIM_NAME = new Regex(@"^\s+|((?<!`)\s)+$");
+
+        /// Regular expression that matches unescaped characters.
+        private static readonly Regex PATTERN_ESCAPE = new Regex(@"([`=])");
+
+        /// Regular expression that matches escaped characters.
+        private static readonly Regex PATTERN_UNESCAPE = new Regex(@"`([`=\s])");
+
+        public TxtResourceRecord(IResourceRecord record, byte[] message, int dataOffset)
+            : base(record) {
+            RawTxtData = ReadTxtData(message, dataOffset);
+            TxtData = String.Join(string.Empty, RawTxtData.Select(x => x.ToString(Encoding.ASCII)));
+            Parse();
+        }
+
+        public TxtResourceRecord(Domain domain, string attributeName, string attributeValue, TimeSpan ttl = default(TimeSpan))
+            : base(new ResourceRecord(domain, CreateTxtData(attributeName, attributeValue), RecordType.TXT, RecordClass.IN, ttl)) {
+            AttributeName = attributeName;
+            AttributeValue = attributeValue;
+        }
+
+        private static CharacterString[] ReadTxtData(byte[] message, int dataOffset) {
+            var result = new List<CharacterString>();
+            while (dataOffset < message.Length) {
+                result.Add(CharacterString.FromArray(message, dataOffset, out var endOffset));
+                dataOffset = endOffset;
+            }
+            return result.ToArray();
+        }
+
+        private static byte[] CreateTxtData(string attributeName, string attributeValue) {
+            var charStrings = CharacterString.FromString($"{Escape(attributeName)}={attributeValue}");
+            return charStrings.SelectMany(c => c.Value).ToArray();
+        }
+
+        private void Parse() {
+            var match = PATTERN_TXT_RECORD.Match(TxtData);
+            if (match.Success) {
+                AttributeName = (match.Groups[1].Length > 0) ? Unescape(Trim(match.Groups[1].ToString())) : null;
+                AttributeValue = Unescape(match.Groups[2].ToString());
+            } else {
+                AttributeName = null;
+                AttributeValue = Unescape(TxtData);
+            }
+        }
+
+        private static string Trim(string value) => PATTERN_TRIM_NAME.Replace(value, string.Empty);
+        private static string Escape(string value) => PATTERN_ESCAPE.Replace(value, "`$1");
+        private static string Unescape(string value) => PATTERN_UNESCAPE.Replace(value, "$1");
+
+        public CharacterString[] RawTxtData { get; }
+        public string TxtData { get; }
+        public string AttributeName { get; private set; }
+        public string AttributeValue { get; private set; }
+
+        public override string ToString() => Stringify().Add("AttributeName", "AttributeValue").ToString();
+    }
+}

--- a/DNS/Server/MasterFile.cs
+++ b/DNS/Server/MasterFile.cs
@@ -76,6 +76,10 @@ namespace DNS.Server {
             Add(new MailExchangeResourceRecord(domain, preference, exchange));
         }
 
+        public void AddTxtResourceRecord(string domain, string attributeName, string attributeValue) {
+            Add(new TxtResourceRecord(new Domain(domain), attributeName, attributeValue, ttl));
+        }
+
         public IList<IResourceRecord> Get(Domain domain, RecordType type) {
             return entries.Where(e => Matches(domain, e.Name) && e.Type == type).ToList();
         }

--- a/Tests/Protocol/ParseCharacterStringTest.cs
+++ b/Tests/Protocol/ParseCharacterStringTest.cs
@@ -1,0 +1,48 @@
+using System;
+using Xunit;
+using DNS.Protocol;
+
+namespace DNS.Tests.Protocol
+{
+
+    public class ParseCharacterStringTest {
+
+        [Fact]
+        public void BasicCharacterString() {
+            var fixture = new byte[] { 0x03, (byte)'f', (byte)'o', (byte)'o' };
+            var result = CharacterString.FromArray(fixture, 0, out var endOffset);
+
+            Assert.Equal(3, result.Value.Length);
+            Assert.Equal("foo", result.ToString());
+            Assert.Equal(4, endOffset);
+        }
+
+        [Fact]
+        public void WithWrongLengthUnder() {
+            var fixture = new byte[] { 0x01, (byte)'f', (byte)'o' };
+            var result = CharacterString.FromArray(fixture, 0, out var endOffset);
+
+            Assert.Equal(1, result.Value.Length);
+            Assert.Equal("f", result.ToString());
+            Assert.Equal(2, endOffset);
+        }
+
+        [Fact]
+        public void WithWrongLengthOver() {
+            var fixture = new byte[] { 0x03, (byte)'f', (byte)'o' };
+            Assert.Throws<ArgumentException>(() => CharacterString.FromArray(fixture, 0));
+        }
+
+        [Fact]
+        public void WithWrongOffset() {
+            var fixture = new byte[] { 0x03, (byte)'f', (byte)'o', (byte)'o' };
+            Assert.Throws<IndexOutOfRangeException>(() => CharacterString.FromArray(fixture, 4));
+        }
+
+        [Fact]
+        public void Empty() {
+            var fixture = new byte[] {};
+            Assert.Throws<ArgumentException>(() => CharacterString.FromArray(fixture, 0));
+        }
+    }
+}

--- a/Tests/Protocol/ResourceRecords/TxtResourceRecordTest.cs
+++ b/Tests/Protocol/ResourceRecords/TxtResourceRecordTest.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text;
+using Xunit;
+using DNS.Protocol.ResourceRecords;
+
+namespace DNS.Tests.Protocol.ResourceRecords
+{
+
+    public class TxtResourceRecordTest {
+
+        [Theory]
+        [InlineData(@"color=blue",      @"color",    @"blue")]
+        [InlineData(@"equation=a=4",    @"equation", @"a=4")]
+        [InlineData(@"a`=a=true",       @"a=a",      @"true")]
+        [InlineData(@"a\`=a=false",     @"a\=a",     @"false")]
+        [InlineData(@"`==\=",           @"=",        @"\=")]
+        [InlineData(@"string=""Cat""",  @"string",   @"""Cat""")]
+        [InlineData(@"string2=``abc``", @"string2",  @"`abc`")]
+        [InlineData(@"novalue=",        @"novalue",  @"")]
+        [InlineData(@"a b=c d",         @"a b",      @"c d")]
+        [InlineData(@"abc` =123 ",      @"abc ",     @"123 ")]
+        public void Rfc1464Examples(string internalForm, string expAttributeName, string expAttributeValue) {
+            var record = new TxtResourceRecord(null, Prepare(internalForm), 0);
+            Assert.Equal(expAttributeName, record.AttributeName);
+            Assert.Equal(expAttributeValue, record.AttributeValue);
+        }
+
+        [Theory]
+        [InlineData(@"test",  @"test",  null, @"test")]
+        [InlineData(@"=test", @"=test", null, @"test")]
+        [InlineData(@"",      @"",      null, @"")]
+        public void NegativeExamples(string input, string expTxtData, string expAttributeName, string expAttributeValue) {
+            var record = new TxtResourceRecord(null, Prepare(input), 0);
+            Assert.Equal(expTxtData, record.TxtData);
+            Assert.Equal(expAttributeName, record.AttributeName);
+            Assert.Equal(expAttributeValue, record.AttributeValue);
+        }
+
+        private byte[] Prepare(string internalForm) {
+            var bytes = Encoding.ASCII.GetBytes(internalForm);
+            var result = new byte[bytes.Length + 1];
+            result[0] = (byte)bytes.Length;
+            Array.Copy(bytes, 0, result, 1, bytes.Length);
+            return result;
+        }
+    }
+}

--- a/Tests/Protocol/SerializeCharacterStringTest.cs
+++ b/Tests/Protocol/SerializeCharacterStringTest.cs
@@ -1,0 +1,37 @@
+using Xunit;
+using DNS.Protocol;
+using System.Linq;
+
+namespace DNS.Tests.Protocol
+{
+
+    public class SerializeCharacterStringTest {
+
+        [Fact]
+        public void EmptyString() {
+            var result = CharacterString.FromString("");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void SimpleString() {
+            var testString = "hello world";
+            var testEncoding = System.Text.Encoding.ASCII;
+            var result = CharacterString.FromString(testString, testEncoding);
+            Assert.Equal(1, result.Count());
+            var resultBytes = result.First().Value;
+            Assert.Equal(testString.Length + 1, resultBytes.Length);
+            Assert.Equal(testString.Length, resultBytes[0]);
+            Assert.Equal(testString, testEncoding.GetString(resultBytes, 1, resultBytes.Length - 1));
+        }
+
+        [Fact]
+        public void LongString() {
+            var testString = new string('a', 512);
+            var result = CharacterString.FromString(testString);
+            Assert.Equal(3, result.Count());
+            Assert.Equal(new []{256, 256, 3}, result.Select(x => x.Value.Length));
+            Assert.Equal(new []{255, 255, 2}, result.Select(x => (int)x.Value[0]));
+        }
+    }
+}


### PR DESCRIPTION
The TXT resource records get parsed as defined in [RFC 1464](https://tools.ietf.org/html/rfc1464).
They can have an attribute name and value delimited by an equal sign.
To support this, the implementation of the "character-class" non-terminal
defined in [RFC 1035](https://tools.ietf.org/html/rfc1035) has been added.
Tests have been added accordingly including the full list of examples given
in [RFC 1464](https://tools.ietf.org/html/rfc1464).
