### PR TITLE
Refactor to extract useful functionality

### DIFF
--- a/DNS/Server/DnsServer.cs
+++ b/DNS/Server/DnsServer.cs
@@ -163,24 +163,5 @@ namespace DNS.Server {
                 finally { OnErrored(e); }
             }
         }
-
-        private class FallbackRequestResolver : IRequestResolver {
-            private IRequestResolver[] resolvers;
-
-            public FallbackRequestResolver(params IRequestResolver[] resolvers) {
-                this.resolvers = resolvers;
-            }
-
-            public async Task<IResponse> Resolve(IRequest request) {
-                IResponse response = null;
-
-                foreach (IRequestResolver resolver in resolvers) {
-                    response = await resolver.Resolve(request);
-                    if (response.AnswerRecords.Count > 0) break;
-                }
-
-                return response;
-            }
-        }
     }
 }

--- a/DNS/Server/FallbackRequestResolver.cs
+++ b/DNS/Server/FallbackRequestResolver.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using DNS.Protocol;
+using DNS.Client.RequestResolver;
+
+namespace DNS.Server {
+    public class FallbackRequestResolver : IRequestResolver {
+        private IRequestResolver[] resolvers;
+
+        public FallbackRequestResolver(params IRequestResolver[] resolvers) {
+            this.resolvers = resolvers;
+        }
+
+        public async Task<IResponse> Resolve(IRequest request) {
+            IResponse response = null;
+
+            foreach (IRequestResolver resolver in resolvers) {
+                response = await resolver.Resolve(request);
+                if (response.AnswerRecords.Count > 0) break;
+            }
+
+            return response;
+        }
+    }
+}

--- a/DNS/Server/MasterFileResolver.cs
+++ b/DNS/Server/MasterFileResolver.cs
@@ -1,0 +1,36 @@
+﻿using DNS.Client.RequestResolver;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DNS.Server {
+    public abstract class MasterFileResolver : IRequestResolver {
+
+        public interface IEntry {
+            IResourceRecord Record { get; }
+            bool IsMatch(Question question);
+        }
+
+        protected IList<IEntry> Entries = new List<IEntry>();
+
+        public Task<IResponse> Resolve(IRequest request) {
+            IResponse response = Response.FromRequest(request);
+
+            foreach (var question in request.Questions) {
+                var matches = Entries.Where(e => e.IsMatch(question)).ToList();
+
+                foreach (var entry in matches) {
+                    response.AnswerRecords.Add(entry.Record);
+                }
+            }
+
+            if (response.AnswerRecords.Count == 0) {
+                response.ResponseCode = ResponseCode.NameError;
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
I'm writing a auto-configuring local DNS server for development, and would like to use some functionality in your `DNS.Server` namespace, but the classes were not written with such re-use in mind.

I propose a slight refactor, which allows the useful pieces to be reused without copy and pasting.

The API and functioning of `MasterFile` is unchanged.