### PR TITLE
Case-insensitive queries and type=ANY

### DIFF
--- a/DNS/DNS.csproj
+++ b/DNS/DNS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Description>Library for parsing and serializing DNS messages. Includes a basic DNS client and server.</Description>
     <Company>Mirza Kapetanovic</Company>
     <Authors>Mirza Kapetanovic</Authors>

--- a/DNS/Server/DnsServer.cs
+++ b/DNS/Server/DnsServer.cs
@@ -137,7 +137,7 @@ namespace DNS.Server {
             catch (IndexOutOfRangeException e) { OnError(e); }
             catch (OperationCanceledException e) { OnError(e); }
             catch (IOException e) { OnError(e); }
-            catch (ObjectDisposedException e) { OnError(e); }
+            catch (ObjectDisposedException) { /* Ignore: During shutdown, udp is just disposed */ }
             catch (ResponseException e) {
                 IResponse response = e.Response;
 

--- a/DNS/Server/MasterFile.cs
+++ b/DNS/Server/MasterFile.cs
@@ -22,7 +22,7 @@ namespace DNS.Server {
                 patterns[i] = label == "*" ? "(\\w+)" : Regex.Escape(label);
             }
 
-            Regex re = new Regex("^" + string.Join("\\.", patterns) + "$");
+            Regex re = new Regex("^" + string.Join("\\.", patterns) + "$", RegexOptions.IgnoreCase);
             return re.IsMatch(domain.ToString());
         }
 
@@ -114,7 +114,7 @@ namespace DNS.Server {
         }
 
         private IList<IResourceRecord> Get(Domain domain, RecordType type) {
-            return entries.Where(e => Matches(domain, e.Name) && e.Type == type).ToList();
+            return entries.Where(e => Matches(domain, e.Name) && (e.Type == type || type == RecordType.ANY)).ToList();
         }
 
         private IList<IResourceRecord> Get(Question question) {

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <StartupObject />
   </PropertyGroup>
 

--- a/Tests/Server/MasterFileTest.cs
+++ b/Tests/Server/MasterFileTest.cs
@@ -11,13 +11,18 @@ using Xunit;
 namespace DNS.Tests.Server {
 	public class MasterFileTest {
 		[Fact]
-		public async Task TestResolve() {
+		public async Task TestResolveMatchingCase() {
 			MasterFile masterFile = new MasterFile();
 			masterFile.AddIPAddressResourceRecord("google.com", "192.168.0.1");
-			{
+			await AssertGoogleResult(RecordType.A, "google.com");
+			await AssertGoogleResult(RecordType.A, "gooGLE.com");
+			await AssertGoogleResult(RecordType.ANY, "google.com");
+			await AssertGoogleResult(RecordType.ANY, "gooGLE.com");
+
+			async Task AssertGoogleResult(RecordType requestType, string question) {
 				//Test matching case.
 				IRequest clientRequest = new Request();
-				Question clientRequestQuestion = new Question(new Domain("google.com"), RecordType.A);
+				Question clientRequestQuestion = new Question(new Domain(question), requestType);
 
 				clientRequest.Id = 1;
 				clientRequest.Questions.Add(clientRequestQuestion);
@@ -33,67 +38,13 @@ namespace DNS.Tests.Server {
 
 				Question clientResponseQuestion = clientResponse.Questions[0];
 
-				Assert.Equal(RecordType.A, clientResponseQuestion.Type);
-				Assert.Equal("google.com", clientResponseQuestion.Name.ToString());
+				Assert.Equal(requestType, clientResponseQuestion.Type);
+				Assert.Equal(question, clientResponseQuestion.Name.ToString());
 
 				var clientResponseAnswer = clientResponse.AnswerRecords[0];
 				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
 				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
 				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord)clientResponseAnswer).IPAddress.ToString());
-			}
-			{
-				//Test different casing.
-				IRequest clientRequest = new Request();
-				Question clientRequestQuestion = new Question(new Domain("gooGLE.com"), RecordType.A);
-
-				clientRequest.Id = 1;
-				clientRequest.Questions.Add(clientRequestQuestion);
-				clientRequest.OperationCode = OperationCode.Query;
-
-				IResponse clientResponse = await masterFile.Resolve(clientRequest);
-
-				Assert.Equal(1, clientResponse.Id);
-				Assert.Equal(1, clientResponse.Questions.Count);
-				Assert.Equal(1, clientResponse.AnswerRecords.Count);
-				Assert.Equal(0, clientResponse.AuthorityRecords.Count);
-				Assert.Equal(0, clientResponse.AdditionalRecords.Count);
-
-				Question clientResponseQuestion = clientResponse.Questions[0];
-
-				Assert.Equal(RecordType.A, clientResponseQuestion.Type);
-				Assert.Equal("gooGLE.com", clientResponseQuestion.Name.ToString());
-
-				var clientResponseAnswer = clientResponse.AnswerRecords[0];
-				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
-				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
-				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord)clientResponseAnswer).IPAddress.ToString());
-			}
-			{
-				//Test RecordType.ANY
-				IRequest clientRequest = new Request();
-				Question clientRequestQuestion = new Question(new Domain("google.com"), RecordType.ANY);
-
-				clientRequest.Id = 1;
-				clientRequest.Questions.Add(clientRequestQuestion);
-				clientRequest.OperationCode = OperationCode.Query;
-
-				IResponse clientResponse = await masterFile.Resolve(clientRequest);
-
-				Assert.Equal(1, clientResponse.Id);
-				Assert.Equal(1, clientResponse.Questions.Count);
-				Assert.Equal(1, clientResponse.AnswerRecords.Count);
-				Assert.Equal(0, clientResponse.AuthorityRecords.Count);
-				Assert.Equal(0, clientResponse.AdditionalRecords.Count);
-
-				Question clientResponseQuestion = clientResponse.Questions[0];
-
-				Assert.Equal(RecordType.ANY, clientResponseQuestion.Type);
-				Assert.Equal("google.com", clientResponseQuestion.Name.ToString());
-
-				var clientResponseAnswer = clientResponse.AnswerRecords[0];
-				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
-				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
-				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord) clientResponseAnswer).IPAddress.ToString());
 			}
 		}
 	}

--- a/Tests/Server/MasterFileTest.cs
+++ b/Tests/Server/MasterFileTest.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using DNS.Server;
+using Xunit;
+
+namespace DNS.Tests.Server {
+	public class MasterFileTest {
+		[Fact]
+		public async Task TestResolve() {
+			MasterFile masterFile = new MasterFile();
+			masterFile.AddIPAddressResourceRecord("google.com", "192.168.0.1");
+			{
+				//Test matching case.
+				IRequest clientRequest = new Request();
+				Question clientRequestQuestion = new Question(new Domain("google.com"), RecordType.A);
+
+				clientRequest.Id = 1;
+				clientRequest.Questions.Add(clientRequestQuestion);
+				clientRequest.OperationCode = OperationCode.Query;
+
+				IResponse clientResponse = await masterFile.Resolve(clientRequest);
+
+				Assert.Equal(1, clientResponse.Id);
+				Assert.Equal(1, clientResponse.Questions.Count);
+				Assert.Equal(1, clientResponse.AnswerRecords.Count);
+				Assert.Equal(0, clientResponse.AuthorityRecords.Count);
+				Assert.Equal(0, clientResponse.AdditionalRecords.Count);
+
+				Question clientResponseQuestion = clientResponse.Questions[0];
+
+				Assert.Equal(RecordType.A, clientResponseQuestion.Type);
+				Assert.Equal("google.com", clientResponseQuestion.Name.ToString());
+
+				var clientResponseAnswer = clientResponse.AnswerRecords[0];
+				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
+				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
+				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord)clientResponseAnswer).IPAddress.ToString());
+			}
+			{
+				//Test different casing.
+				IRequest clientRequest = new Request();
+				Question clientRequestQuestion = new Question(new Domain("gooGLE.com"), RecordType.A);
+
+				clientRequest.Id = 1;
+				clientRequest.Questions.Add(clientRequestQuestion);
+				clientRequest.OperationCode = OperationCode.Query;
+
+				IResponse clientResponse = await masterFile.Resolve(clientRequest);
+
+				Assert.Equal(1, clientResponse.Id);
+				Assert.Equal(1, clientResponse.Questions.Count);
+				Assert.Equal(1, clientResponse.AnswerRecords.Count);
+				Assert.Equal(0, clientResponse.AuthorityRecords.Count);
+				Assert.Equal(0, clientResponse.AdditionalRecords.Count);
+
+				Question clientResponseQuestion = clientResponse.Questions[0];
+
+				Assert.Equal(RecordType.A, clientResponseQuestion.Type);
+				Assert.Equal("gooGLE.com", clientResponseQuestion.Name.ToString());
+
+				var clientResponseAnswer = clientResponse.AnswerRecords[0];
+				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
+				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
+				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord)clientResponseAnswer).IPAddress.ToString());
+			}
+			{
+				//Test RecordType.ANY
+				IRequest clientRequest = new Request();
+				Question clientRequestQuestion = new Question(new Domain("google.com"), RecordType.ANY);
+
+				clientRequest.Id = 1;
+				clientRequest.Questions.Add(clientRequestQuestion);
+				clientRequest.OperationCode = OperationCode.Query;
+
+				IResponse clientResponse = await masterFile.Resolve(clientRequest);
+
+				Assert.Equal(1, clientResponse.Id);
+				Assert.Equal(1, clientResponse.Questions.Count);
+				Assert.Equal(1, clientResponse.AnswerRecords.Count);
+				Assert.Equal(0, clientResponse.AuthorityRecords.Count);
+				Assert.Equal(0, clientResponse.AdditionalRecords.Count);
+
+				Question clientResponseQuestion = clientResponse.Questions[0];
+
+				Assert.Equal(RecordType.ANY, clientResponseQuestion.Type);
+				Assert.Equal("google.com", clientResponseQuestion.Name.ToString());
+
+				var clientResponseAnswer = clientResponse.AnswerRecords[0];
+				Assert.Equal(RecordType.A, clientResponseAnswer.Type);
+				Assert.Equal("google.com", clientResponseAnswer.Name.ToString());
+				Assert.Equal("192.168.0.1", ((IPAddressResourceRecord) clientResponseAnswer).IPAddress.ToString());
+			}
+		}
+	}
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed two issues when using the MasterFile:
- Queries are case-sensitive, while DNS is case-insensitive.
- Queries using type=ANY do never return any results.

This should fix both.