### PR TITLE
Fix not following RFC6763 section 6.3

### DIFF
--- a/DNS/Protocol/ResourceRecords/TextResourceRecord.cs
+++ b/DNS/Protocol/ResourceRecords/TextResourceRecord.cs
@@ -56,20 +56,22 @@ namespace DNS.Protocol.ResourceRecords {
 
         public IList<CharacterString> TextData { get; }
 
-        public KeyValuePair<string, string> Attribute {
-            get {
-                string text = ToStringTextData();
-                Match match = PATTERN_TXT_RECORD.Match(text);
+        public IEnumerable<KeyValuePair<string, string>> Attributes {
+            get =>
+                this.TextData.Select(chrStr =>
+                {
+                    var text = chrStr.ToString();
+                    Match match = PATTERN_TXT_RECORD.Match(text);
 
-                if (match.Success) {
-                    string attributeName = (match.Groups[1].Length > 0) ?
-                        Unescape(Trim(match.Groups[1].ToString())) : null;
-                    string attributeValue = Unescape(match.Groups[2].ToString());
-                    return new KeyValuePair<string, string>(attributeName, attributeValue);
-                } else {
-                    return new KeyValuePair<string, string>(null, Unescape(text));
-                }
-            }
+                    if (match.Success) {
+                        string attributeName = (match.Groups[1].Length > 0) ?
+                            Unescape(Trim(match.Groups[1].ToString())) : null;
+                        string attributeValue = Unescape(match.Groups[2].ToString());
+                        return new KeyValuePair<string, string>(attributeName, attributeValue);
+                    } else {
+                        return new KeyValuePair<string, string>(null, Unescape(text));
+                    }
+                });
         }
 
         public string ToStringTextData() {
@@ -81,7 +83,8 @@ namespace DNS.Protocol.ResourceRecords {
         }
 
         public override string ToString() {
-            return Stringify().Add("TextData", (object) ToStringTextData()).ToString();
+            var list = String.Join(" ", TextData.Select(c => c.ToString()));
+            return Stringify().Add("TextData", (object) list).ToString();
         }
     }
 }

--- a/Tests/Protocol/ResourceRecords/TextResourceRecordTest.cs
+++ b/Tests/Protocol/ResourceRecords/TextResourceRecordTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Xunit;
 using DNS.Protocol.ResourceRecords;
 using DNS.Protocol;
+using System.Linq;
 
 namespace DNS.Tests.Protocol.ResourceRecords {
 
@@ -21,7 +22,7 @@ namespace DNS.Tests.Protocol.ResourceRecords {
         [InlineData("abc` =123 ", "abc ", "123 ")]
         public void Rfc1464Examples(string internalForm, string expAttributeName, string expAttributeValue) {
             TextResourceRecord record = new TextResourceRecord(new ArrayTextResourceRecord(internalForm));
-            KeyValuePair<string, string> attribute = record.Attribute;
+            KeyValuePair<string, string> attribute = record.Attributes.First();
             Assert.Equal(expAttributeName, attribute.Key);
             Assert.Equal(expAttributeValue, attribute.Value);
         }
@@ -32,7 +33,7 @@ namespace DNS.Tests.Protocol.ResourceRecords {
         [InlineData("", "", null, "")]
         public void NegativeExamples(string input, string expTxtData, string expAttributeName, string expAttributeValue) {
             TextResourceRecord record = new TextResourceRecord(new ArrayTextResourceRecord(input));
-            KeyValuePair<string, string> attribute = record.Attribute;
+            KeyValuePair<string, string> attribute = record.Attributes.First();
 
             Assert.Equal(expTxtData, record.ToStringTextData());
             Assert.Equal(expAttributeName, attribute.Key);


### PR DESCRIPTION
RFC6763 section 6.3:
Specifies that each key/value pair is encoded as its own constituent string. So each bytes length + string is a key value pair.

I tested this with an IPMX registry device.

Before the fix the Attribute where mangled (a single key/pair).

After the proposed fix each Key Value pairs matches the output from standard tools like dig.